### PR TITLE
独自記法の実装，テストを追加

### DIFF
--- a/ast/commentout.go
+++ b/ast/commentout.go
@@ -9,11 +9,12 @@ type Commentout struct {
 	gast.BaseInline
 }
 
-// Dump helper
+// Dump implements Node.Dump.
 func (n *Commentout) Dump(source []byte, level int) {
 	gast.DumpHelper(n, source, level, nil, nil)
 }
 
+// KindCommentout is a NodeKind of the Commentout node.
 var KindCommentout = gast.NewNodeKind("Commentout")
 
 // Kind implements Node.Kind.
@@ -21,6 +22,7 @@ func (n *Commentout) Kind() gast.NodeKind {
 	return KindCommentout
 }
 
+// NewCommentout returns a new Commentout node
 func NewCommentout() *Commentout {
 	return &Commentout{}
 }

--- a/commentout.go
+++ b/commentout.go
@@ -34,6 +34,7 @@ type commentoutParser struct {
 
 var defaultCommentoutParser = &commentoutParser{}
 
+// NewCommentoutParser returns a new CommentoutParser
 func NewCommentoutParser() parser.InlineParser {
 	return defaultCommentoutParser
 }
@@ -59,10 +60,12 @@ func (s *commentoutParser) CloseBlock(parent gast.Node, pc parser.Context) {
 	// nothing to do
 }
 
+// CommentoutHTMLRenderer is a renderer.NodeRenderer implementation that renders comementout
 type CommentoutHTMLRenderer struct {
 	html.Config
 }
 
+// NewCommentoutHTMLRenderer returns a new CommentoutHTMLRenderer
 func NewCommentoutHTMLRenderer(opts ...html.Option) renderer.NodeRenderer {
 	r := &CommentoutHTMLRenderer{
 		Config: html.NewConfig(),
@@ -73,6 +76,7 @@ func NewCommentoutHTMLRenderer(opts ...html.Option) renderer.NodeRenderer {
 	return r
 }
 
+// RegisterFuncs implements renderer.NodeRenderer.RegisterFuncs.
 func (r *CommentoutHTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
 	reg.Register(ast.KindCommentout, r.renderCommentout)
 }
@@ -93,6 +97,7 @@ type commentoutASTTransformer struct {
 
 var defaultCommentoutASTTransformer = &commentoutASTTransformer{}
 
+// NewCommentoutASTTransformer returns a new CommentoutASTTransformar
 func NewCommentoutASTTransformer() parser.ASTTransformer {
 	return defaultCommentoutASTTransformer
 }
@@ -126,6 +131,7 @@ func (a *commentoutASTTransformer) Transform(node *gast.Document, reader text.Re
 type commentout struct {
 }
 
+// Commentout is an extension that allow you to use commentout expression like '<!-- something -->'
 var Commentout = &commentout{}
 
 func (e *commentout) Extend(m goldmark.Markdown) {

--- a/commentout.go
+++ b/commentout.go
@@ -16,7 +16,7 @@ type commentoutDelimiterProcessor struct {
 }
 
 func (p *commentoutDelimiterProcessor) IsDelimiter(b byte) bool {
-	return b == '/' || b == ' '
+	return b == '/'
 }
 
 func (p *commentoutDelimiterProcessor) CanOpenCloser(opener, closer *parser.Delimiter) bool {

--- a/commentout.go
+++ b/commentout.go
@@ -81,8 +81,6 @@ func (r *CommentoutHTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegi
 	reg.Register(ast.KindCommentout, r.renderCommentout)
 }
 
-var CommentoutAttributeFilter = html.GlobalAttributeFilter
-
 func (r *CommentoutHTMLRenderer) renderCommentout(w util.BufWriter, source []byte, n gast.Node, entering bool) (gast.WalkStatus, error) {
 	if entering {
 		_, _ = w.WriteString("<!-- ")

--- a/commentout_test.go
+++ b/commentout_test.go
@@ -14,10 +14,21 @@ func TestCommentout(t *testing.T) {
 			Commentout,
 		),
 	)
-	var buf bytes.Buffer
 
-	source := []byte("//TODO: abc//")
-	err := md.Convert(source, &buf)
-	assert.NoError(t, err)
-	assert.Equal(t, "<p><!-- TODO: abc --></p>\n", buf.String())
+	commentoutTests := []struct {
+		actual   string
+		expected string
+	}{
+		{"//TODO: something//", "<!-- TODO: something -->"},
+		{"123//TODO: something//", "<p>123</p>\n<!-- TODO: something -->"},
+		{"//TODO: something//456", "<!-- TODO: something --><p>456</p>\n"},
+		{"123//TODO: something//456", "<p>123456</p>\n<!-- TODO: something -->"},
+	}
+
+	for _, commentout := range commentoutTests {
+		var buf bytes.Buffer
+		err := md.Convert([]byte(commentout.actual), &buf)
+		assert.NoError(t, err)
+		assert.Equal(t, commentout.expected, buf.String())
+	}
 }


### PR DESCRIPTION
- コメントアウトの実装を改変
  - パラグラフノード以下にノードがない場合はp tagを削除
  - p tagとコメントアウトのノードの順番を考慮
- コメントアウトを行うテストを追加
- ソースコードにコメントを色々追加